### PR TITLE
Release 213-0.5.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 pluginGroup = com.justai.jaicf.plugin
 pluginName = Jaicf Plugin
-pluginVersion = 213-0.5.3
+pluginVersion = 213-0.5.4
 
 pluginSinceBuild = 213
 pluginUntilBuild = 213.*

--- a/src/main/kotlin/com/justai/jaicf/plugin/contexts/StateContext.kt
+++ b/src/main/kotlin/com/justai/jaicf/plugin/contexts/StateContext.kt
@@ -3,12 +3,16 @@ package com.justai.jaicf.plugin.contexts
 import com.intellij.codeInsight.template.TemplateActionContext
 import com.intellij.codeInsight.template.TemplateContextType
 import com.justai.jaicf.plugin.scenarios.psi.builders.isStateDeclaration
+import com.justai.jaicf.plugin.utils.VersionService
 import com.justai.jaicf.plugin.utils.boundedCallExpressionOrNull
 import com.justai.jaicf.plugin.utils.getBoundedLambdaArgumentOrNull
+import com.justai.jaicf.plugin.utils.isJaicfInclude
 import org.jetbrains.kotlin.psi.KtCallExpression
 
 class StateContext : TemplateContextType("STATE", "State") {
     override fun isInContext(templateActionContext: TemplateActionContext): Boolean {
+        if (!VersionService.getInstance(templateActionContext.file.project).isJaicfInclude) return false
+
         val probeElement = templateActionContext.file.findElementAt(templateActionContext.startOffset)
         val boundedLambda = probeElement?.getBoundedLambdaArgumentOrNull(KtCallExpression::class.java) ?: return false
         return boundedLambda.boundedCallExpressionOrNull?.isStateDeclaration == true

--- a/src/main/kotlin/com/justai/jaicf/plugin/inspections/Visitors.kt
+++ b/src/main/kotlin/com/justai/jaicf/plugin/inspections/Visitors.kt
@@ -11,8 +11,10 @@ import com.justai.jaicf.plugin.notifications.checkEnvironmentAndNotify
 import com.justai.jaicf.plugin.scenarios.psi.ScenarioDataService
 import com.justai.jaicf.plugin.scenarios.psi.dto.State
 import com.justai.jaicf.plugin.utils.StatePathExpression
+import com.justai.jaicf.plugin.utils.VersionService
 import com.justai.jaicf.plugin.utils.innerPathExpressions
 import com.justai.jaicf.plugin.utils.isExist
+import com.justai.jaicf.plugin.utils.isJaicfInclude
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -86,7 +88,9 @@ abstract class AnnotatedElementVisitor(holder: ProblemsHolder) : VisitorBase(hol
 abstract class VisitorBase(private val holder: ProblemsHolder) : PsiElementVisitor() {
 
     fun checkEnvironmentAndNotify(element: PsiElement): Boolean {
+        if (VersionService.getInstance(element)?.isJaicfInclude == false) return false
         val project = if (element.isExist) element.project else return false
+
         return checkEnvironmentAndNotify(project)
     }
 

--- a/src/main/kotlin/com/justai/jaicf/plugin/providers/LineMarkerProviders.kt
+++ b/src/main/kotlin/com/justai/jaicf/plugin/providers/LineMarkerProviders.kt
@@ -16,10 +16,12 @@ import com.justai.jaicf.plugin.scenarios.psi.dto.name
 import com.justai.jaicf.plugin.scenarios.transition.absolutePath
 import com.justai.jaicf.plugin.scenarios.transition.statesOrSuggestions
 import com.justai.jaicf.plugin.scenarios.transition.transitToState
+import com.justai.jaicf.plugin.utils.VersionService
 import com.justai.jaicf.plugin.utils.asLeaf
 import com.justai.jaicf.plugin.utils.findChildOfType
 import com.justai.jaicf.plugin.utils.getBoundedCallExpressionOrNull
 import com.justai.jaicf.plugin.utils.holderExpression
+import com.justai.jaicf.plugin.utils.isJaicfInclude
 import com.justai.jaicf.plugin.utils.isRemoved
 import com.justai.jaicf.plugin.utils.pathExpressionsOfBoundedBlock
 import javax.swing.Icon
@@ -34,6 +36,8 @@ class StatePathLineMarkerProvider : RelatedItemLineMarkerProvider() {
         element: PsiElement,
         result: MutableCollection<in RelatedItemLineMarkerInfo<*>>,
     ) {
+        if (VersionService.getInstance(element)?.isJaicfInclude == false) return
+
         if (element.isRemoved || isNotLeafIdentifier(element)) return
 
         val pathExpressions = element.pathExpressionsOfBoundedBlock
@@ -52,7 +56,7 @@ class StatePathLineMarkerProvider : RelatedItemLineMarkerProvider() {
 
     private fun buildLineMarker(
         expression: PsiElement,
-        markerHolderLeaf: LeafPsiElement
+        markerHolderLeaf: LeafPsiElement,
     ): RelatedItemLineMarkerInfo<PsiElement> =
         NavigationGutterIconBuilder.create(GO_TO_STATES)
             .setAlignment(LEFT)
@@ -68,6 +72,8 @@ class StateIdentifierLineMarkerProvider : RelatedItemLineMarkerProvider() {
         element: PsiElement,
         result: MutableCollection<in RelatedItemLineMarkerInfo<*>>,
     ) {
+        if (VersionService.getInstance(element)?.isJaicfInclude == false) return
+
         if (element.isRemoved || isNotLeafIdentifier(element)) return
 
         val callExpression = element.getBoundedCallExpressionOrNull(KtValueArgument::class.java) ?: return

--- a/src/main/kotlin/com/justai/jaicf/plugin/providers/StateIdentifierReferenceContributor.kt
+++ b/src/main/kotlin/com/justai/jaicf/plugin/providers/StateIdentifierReferenceContributor.kt
@@ -17,10 +17,12 @@ import com.justai.jaicf.plugin.scenarios.linker.usages
 import com.justai.jaicf.plugin.scenarios.psi.builders.isStateDeclaration
 import com.justai.jaicf.plugin.utils.STATE_NAME_ARGUMENT_NAME
 import com.justai.jaicf.plugin.utils.StatePathExpression
+import com.justai.jaicf.plugin.utils.VersionService
 import com.justai.jaicf.plugin.utils.boundedCallExpressionOrNull
 import com.justai.jaicf.plugin.utils.getBoundedValueArgumentOrNull
 import com.justai.jaicf.plugin.utils.holderExpression
 import com.justai.jaicf.plugin.utils.identifier
+import com.justai.jaicf.plugin.utils.isJaicfInclude
 import com.justai.jaicf.plugin.utils.rangeToEndOf
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
@@ -38,6 +40,7 @@ class StateIdentifierReferenceProvider : PsiReferenceProvider() {
 
     @ExperimentalStdlibApi
     override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
+        if (VersionService.getInstance(element)?.isJaicfInclude == false) return emptyArray()
 
         val argument = element.getBoundedValueArgumentOrNull() ?: return emptyArray()
 

--- a/src/main/kotlin/com/justai/jaicf/plugin/providers/StatePathReferenceContributor.kt
+++ b/src/main/kotlin/com/justai/jaicf/plugin/providers/StatePathReferenceContributor.kt
@@ -20,7 +20,9 @@ import com.justai.jaicf.plugin.scenarios.transition.statesOrSuggestions
 import com.justai.jaicf.plugin.scenarios.transition.transit
 import com.justai.jaicf.plugin.scenarios.transition.transitionsWithRanges
 import com.justai.jaicf.plugin.utils.StatePathExpression.Joined
+import com.justai.jaicf.plugin.utils.VersionService
 import com.justai.jaicf.plugin.utils.boundedPathExpression
+import com.justai.jaicf.plugin.utils.isJaicfInclude
 import com.justai.jaicf.plugin.utils.isSimpleStringTemplate
 import com.justai.jaicf.plugin.utils.rangeToEndOf
 import com.justai.jaicf.plugin.utils.stringValueOrNull
@@ -38,6 +40,7 @@ class StatePathReferenceContributor : PsiReferenceContributor() {
 class StatePathReferenceProvider : PsiReferenceProvider() {
 
     override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
+        if (VersionService.getInstance(element)?.isJaicfInclude == false) return emptyArray()
 
         val statePathExpression = element.boundedPathExpression as? Joined ?: return emptyArray()
         val pathExpression = statePathExpression.declaration

--- a/src/main/kotlin/com/justai/jaicf/plugin/scenarios/linker/ScenarioReferenceResolver.kt
+++ b/src/main/kotlin/com/justai/jaicf/plugin/scenarios/linker/ScenarioReferenceResolver.kt
@@ -14,7 +14,7 @@ import com.justai.jaicf.plugin.utils.SCENARIO_MODEL_FIELD_NAME
 import com.justai.jaicf.plugin.utils.argumentExpressionOrDefaultValue
 import com.justai.jaicf.plugin.utils.isExist
 import com.justai.jaicf.plugin.utils.isRemoved
-import org.jetbrains.kotlin.nj2k.postProcessing.resolve
+import com.justai.jaicf.plugin.utils.safeResolve
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtDeclarationContainer
@@ -53,7 +53,7 @@ class ScenarioReferenceResolver(project: Project) : JaicfService(project) {
     }
 
     private fun getScenarioBody(scenarioReference: KtReferenceExpression, boundedState: State? = null): KtExpression? {
-        when (val resolvedElement = scenarioReference.resolve()) {
+        when (val resolvedElement = scenarioReference.safeResolve()) {
             is KtObjectDeclaration -> {
                 return resolvedElement.scenarioBody
             }
@@ -87,7 +87,7 @@ class ScenarioReferenceResolver(project: Project) : JaicfService(project) {
     private fun getScenarioBody(callExpression: KtCallExpression): KtExpression? {
         if (callExpression.isStateDeclaration) return callExpression
 
-        return when (val resolved = callExpression.referenceExpression()?.resolve()) {
+        return when (val resolved = callExpression.referenceExpression()?.safeResolve()) {
             is KtNamedFunction -> (resolved.initializer as? KtCallExpression)?.let {
                 if (it.isStateDeclaration) it else null
             }

--- a/src/main/kotlin/com/justai/jaicf/plugin/utils/ConstantResolver.kt
+++ b/src/main/kotlin/com/justai/jaicf/plugin/utils/ConstantResolver.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiModificationTracker
 import org.jetbrains.kotlin.idea.inspections.AbstractRangeInspection.Companion.constantValueOrNull
-import org.jetbrains.kotlin.nj2k.postProcessing.resolve
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry
 import org.jetbrains.kotlin.psi.KtExpression
@@ -56,7 +55,7 @@ class ConstantResolver(project: Project) {
                 element.expression?.let { resolve(it) }
 
             element is KtNameReferenceExpression ->
-                (element.resolve() as? KtProperty)?.initializer?.let { resolve(it) }
+                (element.safeResolve() as? KtProperty)?.initializer?.let { resolve(it) }
                     ?: element.constantValueOrNull()?.value?.toString()
 
             element is KtExpression ->

--- a/src/main/kotlin/com/justai/jaicf/plugin/utils/PsiElementUtils.kt
+++ b/src/main/kotlin/com/justai/jaicf/plugin/utils/PsiElementUtils.kt
@@ -1,11 +1,11 @@
 package com.justai.jaicf.plugin.utils
 
+import com.intellij.openapi.project.IndexNotReadyException
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.SlowOperations.allowSlowOperations
-import java.lang.Integer.min
 import org.jetbrains.kotlin.idea.core.receiverType
 import org.jetbrains.kotlin.idea.debugger.sequence.psi.callName
 import org.jetbrains.kotlin.name.FqName
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.types.AbbreviatedType
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.supertypes
 import org.jetbrains.kotlin.utils.ifEmpty
+import java.lang.Integer.min
 
 fun KtCallElement.argumentConstantValue(identifier: String) =
     argumentExpression(identifier)?.stringValueOrNull
@@ -115,9 +116,16 @@ val KtCallElement.referenceExpression: KtReferenceExpression?
     get() = findChildOfType<KtNameReferenceExpression>()
 
 val KtReferenceExpression.resolveToSource: KtFunction?
-    get() = (resolve() as? KtFunction)?.let {
+    get() = (safeResolve() as? KtFunction)?.let {
         if (it.isBinary) it.source
         else it
+    }
+
+fun KtReferenceExpression.safeResolve() =
+    try {
+        resolve()
+    } catch (e: IndexNotReadyException) {
+        null
     }
 
 inline fun <reified T : PsiElement> PsiElement.findChildOfType(): T? {
@@ -131,8 +139,8 @@ inline fun <reified T : PsiElement> PsiElement.findChildrenOfType(): Collection<
 fun KtCallExpression.isOverride(receiver: FqName, funName: String, parameters: List<String>? = null) =
     try {
         isExist && callName() == funName
-            && isReceiverInheritedOf(receiver)
-            && (parameters?.let { it == parametersTypes } ?: true)
+                && isReceiverInheritedOf(receiver)
+                && (parameters?.let { it == parametersTypes } ?: true)
     } catch (e: NullPointerException) {
         false
     }
@@ -173,7 +181,7 @@ fun PsiElement.getBoundedLambdaArgumentOrNull(vararg stopAt: Class<out PsiElemen
 
 fun PsiElement.getFirstBoundedElement(
     targetTypes: List<Class<out PsiElement>>,
-    allowedTypes: List<Class<out PsiElement>>? = null
+    allowedTypes: List<Class<out PsiElement>>? = null,
 ): PsiElement? {
     var currentParent = parent
     while (currentParent != null) {
@@ -250,8 +258,8 @@ fun PsiElement.rangeToEndOf(parent: PsiElement): TextRange {
 val KtBinaryExpression.operands get() = left?.let { l -> right?.let { r -> listOf(l, r) } }
 
 val KtBinaryExpression.isStringConcatenationExpression
-    get() = (operationReference.resolve() as? KtFunction)?.let { declaration ->
+    get() = (operationReference.safeResolve() as? KtFunction)?.let { declaration ->
         declaration.name == "plus" &&
-            declaration.receiverName == "kotlin.String" &&
-            declaration.parametersTypes.singleOrNull() == "kotlin.Any"
+                declaration.receiverName == "kotlin.String" &&
+                declaration.parametersTypes.singleOrNull() == "kotlin.Any"
     } ?: false

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -96,5 +96,7 @@
 
         <notificationGroup id="Incompatible Versions Jaicf Plugin Group" displayType="STICKY_BALLOON"/>
         <notificationGroup id="Missed Sources Jaicf Plugin Group" displayType="STICKY_BALLOON"/>
+        
+        <dependencySupport coordinate="com.just-ai.jaicf:core" kind="java"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Fixed: 

- Some features may run in not JAICF projects. The plugin now works only in projects importing JAICF core;
- Suppress errors if IDEA requests plugin extensions before the index is ready.
Implemented:

- Support for the IDEA plugin recommendation system. Now if your project has JAICF core dependency and JAICF plugin is not installed, then IDEA will suggest to install the plugin using the balloon notification.