### PR TITLE
Release 222-0.5.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,8 +9,8 @@ fun properties(key: String) = project.findProperty(key).toString()
 plugins {
     id("java")
 
-    id("org.jetbrains.kotlin.jvm") version "1.4.21"
-    id("org.jetbrains.intellij") version "1.1.2"
+    id("org.jetbrains.kotlin.jvm") version "1.7.0"
+    id("org.jetbrains.intellij") version "1.13.3"
     id("org.jetbrains.changelog") version "1.1.2"
 }
 
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-project:1.4.32")
+    implementation("org.jetbrains.kotlin:kotlin-project:1.7.0")
 }
 
 intellij {
@@ -42,11 +42,11 @@ changelog {
 
 tasks {
     withType<JavaCompile> {
-        sourceCompatibility = "1.8"
-        targetCompatibility = "1.8"
+        sourceCompatibility = "11"
+        targetCompatibility = "11"
     }
     withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "1.8"
+        kotlinOptions.jvmTarget = "11"
     }
 
     patchPluginXml {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 pluginGroup = com.justai.jaicf.plugin
 pluginName = Jaicf Plugin
-pluginVersion = 212-0.5.3
+pluginVersion = 222-0.5.3
 
-pluginSinceBuild = 212
-pluginUntilBuild = 212.*
+pluginSinceBuild = 222
+pluginUntilBuild = 222.*
 
-pluginVerifierIdeVersions = 2021.2.3
+pluginVerifierIdeVersions = 2022.2
 
 platformType = IC
-platformVersion = 2021.2.3
+platformVersion = 2022.2
 platformDownloadSources = true
 
 platformPlugins = com.intellij.java, org.jetbrains.kotlin

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/justai/jaicf/plugin/inspections/StatePathInspections.kt
+++ b/src/main/kotlin/com/justai/jaicf/plugin/inspections/StatePathInspections.kt
@@ -48,6 +48,8 @@ class StatePathInspection : LocalInspectionTool() {
                         NavigateToState("Go to unrelated state declaration ${suggestion.fullPath}", suggestion)
                     )
                 }
+                //TODO fill all transition result or create correct else result
+                else -> {}
             }
         }
     }

--- a/src/main/kotlin/com/justai/jaicf/plugin/utils/ConstantResolver.kt
+++ b/src/main/kotlin/com/justai/jaicf/plugin/utils/ConstantResolver.kt
@@ -3,7 +3,7 @@ package com.justai.jaicf.plugin.utils
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiModificationTracker
-import org.jetbrains.kotlin.idea.inspections.AbstractPrimitiveRangeToInspection.Companion.constantValueOrNull
+import org.jetbrains.kotlin.idea.inspections.AbstractRangeInspection.Companion.constantValueOrNull
 import org.jetbrains.kotlin.nj2k.postProcessing.resolve
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockStringTemplateEntry


### PR DESCRIPTION
Fixed: 

- Some features may run in not JAICF projects. The plugin now works only in projects importing JAICF core;
- Suppress errors if IDEA requests plugin extensions before the index is ready.
Implemented:

- Support for the IDEA plugin recommendation system. Now if your project has JAICF core dependency and JAICF plugin is not installed, then IDEA will suggest to install the plugin using the balloon notification.